### PR TITLE
add judgements feature

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
 # hellmer 0.1.0
 
+## New features
 * Initial CRAN submission.
+
+## Experimental features
+* Development version now supports LLM-as-a-judge refinement for structured data extractions via the `judgements` parameter.

--- a/R/classes.R
+++ b/R/classes.R
@@ -94,6 +94,7 @@ structured_data <- S7::new_generic("structured_data", "x")
 #' @param completed Integer indicating number of completed prompts
 #' @param state_path Path to save state file
 #' @param type_spec Type specification for structured data extraction
+#' @param judgements Number of judgements in a `batch_judge()` workflow (1 = initial extract + 1 judgement, 2 = initial extract + 2 judgements, etc.)
 #' @param echo Level of output to display ("none", "text", "all")
 #' @param input_type Type of input ("vector" or "list")
 #' @param max_retries Maximum number of retry attempts
@@ -171,6 +172,18 @@ batch <- S7::new_class(
           if (!inherits(value, c("ellmer::TypeObject", "ellmer::Type", "ellmer::TypeArray"))) {
             return("@type_spec must be an ellmer type specification (created with type_object(), type_array(), etc.) or NULL")
           }
+        }
+        NULL
+      }
+    ),
+    judgements = S7::new_property(
+      class = S7::class_integer,
+      validator = function(value) {
+        if (length(value) != 1) {
+          "@judgements must be a single integer"
+        }
+        if (value < 0) {
+          "@judgements must be non-negative"
         }
         NULL
       }

--- a/R/hellmer.R
+++ b/R/hellmer.R
@@ -26,7 +26,7 @@
 #'     \item progress: Function to get processing status
 #'     \item structured_data: Function to extract structured data (if `type_spec` was provided)
 #'   }
-#' @examplesIf ellmer::has_credentials("openai")
+#' @examplesIf hellmer::has_credentials("openai")
 #' # Create a sequential chat processor
 #' chat <- chat_sequential(chat_openai, system_prompt = "Reply concisely, one sentence")
 #'
@@ -40,7 +40,7 @@
 #' # Check the progress if interrupted
 #' batch$progress()
 #'
-#' # Return the responses as a vector or list
+#' # Return the responses
 #' batch$texts()
 #'
 #' # Return the chat objects
@@ -82,7 +82,16 @@ chat_sequential <- function(
 
   chat_env$batch <- function(prompts,
                              type_spec = NULL,
+                             judgements = 0,
                              state_path = tempfile("chat_", fileext = ".rds")) {
+    if (judgements > 0 && is.null(type_spec)) {
+      cli::cli_alert_warning("Judgements parameter ({judgements}) specified but will be ignored without a type_spec")
+    }
+
+    if (!is.null(type_spec) && judgements < 0) {
+      cli::cli_abort("Number of judgements must be non-negative")
+    }
+
     if (is.null(chat_env$last_state_path)) {
       chat_env$last_state_path <- state_path
     } else {
@@ -93,6 +102,7 @@ chat_sequential <- function(
       chat_obj = chat_env$chat_model,
       prompts = prompts,
       type_spec = type_spec,
+      judgements = judgements,
       state_path = state_path,
       echo = chat_env$echo,
       max_retries = chat_env$max_retries,
@@ -139,7 +149,7 @@ chat_sequential <- function(
 #'     \item progress: Function to get processing status
 #'     \item structured_data: Function to extract structured data (if `type_spec` was provided)
 #'   }
-#' @examplesIf ellmer::has_credentials("openai")
+#' @examplesIf hellmer::has_credentials("openai")
 #' # Create a parallel chat processor
 #' chat <- chat_future(chat_openai, system_prompt = "Reply concisely, one sentence")
 #'
@@ -153,7 +163,7 @@ chat_sequential <- function(
 #' # Check the progress if interrupted
 #' batch$progress()
 #'
-#' # Return the responses as a vector or list
+#' # Return the responses
 #' batch$texts()
 #'
 #' # Return the chat objects
@@ -202,8 +212,17 @@ chat_future <- function(
 
   chat_env$batch <- function(prompts,
                              type_spec = NULL,
+                             judgements = 0,
                              state_path = tempfile("chat_", fileext = ".rds"),
                              chunk_size = chat_env$chunk_size) {
+    if (judgements > 0 && is.null(type_spec)) {
+      cli::cli_alert_warning("Judgements parameter ({judgements}) specified but will be ignored without a type_spec")
+    }
+
+    if (!is.null(type_spec) && judgements < 0) {
+      cli::cli_abort("Number of judgements must be non-negative")
+    }
+
     if (is.null(chat_env$last_state_path)) {
       chat_env$last_state_path <- state_path
     } else {
@@ -214,6 +233,7 @@ chat_future <- function(
       chat_obj = chat_env$chat_model,
       prompts = prompts,
       type_spec = type_spec,
+      judgements = judgements,
       state_path = state_path,
       workers = chat_env$workers,
       chunk_size = chunk_size,

--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ result$structured_data()
 # ...
 ```
 
+A new experimental feature (dev only) allows you to use your LLM-as-a-judge to refine your structured data extractions:
+
+``` r
+result <- chat$batch(prompts, type_spec = type_sentiment, judgements = 1)
+```
+
 ### State Management
 
 Batch processing automatically saves state as a file and can resume interrupted operations:

--- a/tests/testthat/test-chat-future.R
+++ b/tests/testthat/test-chat-future.R
@@ -38,6 +38,23 @@ test_that("chat_future handles structured data", {
   expect_true(all(sapply(data, function(x) !is.null(x$score))))
 })
 
+test_that("chat_future handles structured data with judgements", {
+  skip_if_not(nzchar(Sys.getenv("ANTHROPIC_API_KEY")), "API key not available")
+
+  chat <- chat_future(ellmer::chat_claude, workers = 1, beep = FALSE)
+  prompts <- list(
+    "I love this!",
+    "This is terrible."
+  )
+
+  result <- chat$batch(prompts, type_spec = get_sentiment_type_spec(), chunk_size = 1, judgements = 1)
+  data <- result$structured_data()
+
+  expect_type(data, "list")
+  expect_length(data, 2)
+  expect_true(all(sapply(data, function(x) !is.null(x$score))))
+})
+
 test_that("chat_future works with tools", {
   skip_if_not(nzchar(Sys.getenv("ANTHROPIC_API_KEY")), "API key not available")
 

--- a/tests/testthat/test-chat-sequential.R
+++ b/tests/testthat/test-chat-sequential.R
@@ -38,6 +38,23 @@ test_that("chat_sequential handles structured data", {
   expect_true(all(sapply(data, function(x) !is.null(x$score))))
 })
 
+test_that("chat_sequential handles structured data with judgements", {
+  skip_if_not(nzchar(Sys.getenv("ANTHROPIC_API_KEY")), "API key not available")
+
+  chat <- chat_sequential(ellmer::chat_claude, beep = FALSE)
+  prompts <- list(
+    "I love this!",
+    "This is terrible."
+  )
+
+  result <- chat$batch(prompts, type_spec = get_sentiment_type_spec(), judgements = 1)
+  data <- result$structured_data()
+
+  expect_type(data, "list")
+  expect_length(data, 2)
+  expect_true(all(sapply(data, function(x) !is.null(x$score))))
+})
+
 test_that("chat_sequential works with tools", {
   skip_if_not(nzchar(Sys.getenv("ANTHROPIC_API_KEY")), "API key not available")
 


### PR DESCRIPTION
adding new behavior to make the chat take more turns and return a more refined response for `type_spec`

example:
``` r
library(hellmer) # dev version

sentiment_schema <- type_object(
  .description = "Extract sentiment analysis",
  positive_score = type_number("Positive sentiment score from 0.00 to 1.00"),
  negative_score = type_number("Negative sentiment score from 0.00 to 1.00"),
  neutral_score = type_number("Neutral sentiment score from 0.00 to 1.00"),
  overall_sentiment = type_string("Overall sentiment: positive, negative, or neutral")
)

text_samples <- list(
  "The R community is really supportive and welcoming. The CRAN repository makes package installation seamless, and resources like R-bloggers provide excellent learning materials. However, some newcomers find the learning curve initially steep.",
  "R has both base functions and tidyverse functions for data manipulation, which provides flexibility but can be confusing for beginners. The pipe operator |> makes code more readable, but having multiple ways to do the same thing causes inconsistency.",
  "R's multiple object-oriented systems (S3, S4, R6, and now S7) are confusing, inconsistent, and painful to use. Documentation is often sparse and the learning curve is unnecessarily steep compared to OOP in other languages."
)

prompts <- paste0("Extract sentiment analysis from this text: ", unlist(text_samples))

chat <- chat_future(chat_openai(), chunk_size = length(prompts))

judged <- chat$batch(
  prompts = prompts,
  type_spec = sentiment_schema,
  judgements = 1
)

# refined data extraction
judged$structured_data()

# check the model's logic
judged$chats()
```